### PR TITLE
Bug:notemate-record-button-css-error

### DIFF
--- a/wlm_front/src/pages/notemate/css/notemate.css
+++ b/wlm_front/src/pages/notemate/css/notemate.css
@@ -478,3 +478,19 @@ button,
 .mic-button.mic-disabled img {
   filter: grayscale(1) brightness(1.2);
 }
+
+.learn-more-style.mic-disabled {
+  background: #e0e0e0 !important;
+  border: 2px solid #bdbdbd !important;
+  color: #888 !important;
+  cursor: not-allowed !important;
+  opacity: 0.7;
+  pointer-events: none; /* 클릭 방지 */
+  text-transform: none; /* 비활성 느낌을 위해 대문자 제거 (선택 사항) */
+}
+
+.learn-more-style.mic-disabled::before {
+  background: #d5d5d5 !important;
+  box-shadow: none !important;
+  transform: none !important;
+}


### PR DESCRIPTION
## 📌 PR Title  
- Bug:notemate-record-button-css-error

---

## ✨ Changes  
- Fixed a CSS issue where the disabled mic button (`.learn-more-style.mic-disabled`) was not fully grayed out.  
- Updated background, border, and icon color to match the disabled state.

---

## 🧪 Tests  
- [x] Tested locally  
- [x] Visual check confirmed

---

## 📎 Related Issues  
#99 

---

## 🙋 Others  
- This was resolved by overriding `.learn-more-style.mic-disabled` styles including `::before` shadow and setting proper opacity.

---

## 📸 Screenshots (Before → After)  

**Before:**  
> Shadow effect remained; not visually disabled.

**After:**  
![스크린샷 2025-05-30 122741](https://github.com/user-attachments/assets/046a02d9-585e-4737-bb0c-68321d80a269)

